### PR TITLE
add: URLのパスで言語を判断して言語を切り替える処理の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
+  around_action :switch_locale
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  private
+  
+  def switch_locale(&action)
+    I18n.with_locale(locale, &action)
+  end
+
+  def locale
+    @locale ||= params[:locale] || I18n.default_locale
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,11 @@ module Ggreports
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # i18n
+    config.i18n.available_locales = %i(ja en)
+    config.i18n.enforce_available_locales = true
+    config.i18n.default_locale = :en
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,16 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  scope '(:locale)', locale: /#{I18n.available_locales.map(&:to_s).join('|')}/ do
+    # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+    # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+    # Can be used by load balancers and uptime monitors to verify that the app is live.
+    get "up" => "rails/health#show", as: :rails_health_check
 
-  # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+    # Render dynamic PWA files from app/views/pwa/*
+    get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+    get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+    # Defines the root path route ("/")
+    # root "posts#index"
+  end
 end


### PR DESCRIPTION
## 概要
URLのパス `/ja`や`/en`などから言語を判断して、表示される言語を切り替える処理の追加

## 変更点
・ 日本語と英語の言語を使用できるようにconfigに設定を追加
・ 日本語のlocaleファイルの追加 `locale/ja.yml`
・ルーティングにlocale対応のスコープを追加
・URLから言語を判断して切り替える処理を追加