### PR TITLE
BASIC認証を一時的に追加

### DIFF
--- a/app/controllers/league_of_legends/top_controller.rb
+++ b/app/controllers/league_of_legends/top_controller.rb
@@ -1,5 +1,9 @@
 class LeagueOfLegends::TopController < ApplicationController
-  http_basic_authenticate_with name: "dev", password: "private-dev"
+  http_basic_authenticate_with(
+    name: ENV['BASIC_AUTH_NAME'],
+    password: ENV['BASIC_AUTH_PASSWORD']
+    )
+
   def index
   end
 end

--- a/app/controllers/league_of_legends/top_controller.rb
+++ b/app/controllers/league_of_legends/top_controller.rb
@@ -1,4 +1,5 @@
 class LeagueOfLegends::TopController < ApplicationController
+  http_basic_authenticate_with name: "dev", password: "private-dev"
   def index
   end
 end

--- a/app/controllers/league_of_legends/top_controller.rb
+++ b/app/controllers/league_of_legends/top_controller.rb
@@ -1,7 +1,7 @@
 class LeagueOfLegends::TopController < ApplicationController
   http_basic_authenticate_with(
-    name: ENV['BASIC_AUTH_NAME'],
-    password: ENV['BASIC_AUTH_PASSWORD']
+    name: ENV["BASIC_AUTH_NAME"],
+    password: ENV["BASIC_AUTH_PASSWORD"]
     )
 
   def index

--- a/spec/requests/league_of_legends/top_spec.rb
+++ b/spec/requests/league_of_legends/top_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper' 
+require 'rails_helper'
 
 RSpec.describe "LeagueOfLegends::Top", type: :request do
   describe "GET /index" do

--- a/spec/requests/league_of_legends/top_spec.rb
+++ b/spec/requests/league_of_legends/top_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'rails_helper' 
 
 RSpec.describe "LeagueOfLegends::Top", type: :request do
   describe "GET /index" do


### PR DESCRIPTION
## 概要
LOLの開発用APIを使用した状態でサービスを一般公開しないようにするためのBASIC認証を追加

**※production APIの申請後、承認が下ったらBASIC認証は削除すること**